### PR TITLE
StaticLink no longer defaults to global debug setting

### DIFF
--- a/docs/source/jinja_templates/writing_jinja_templates.rst
+++ b/docs/source/jinja_templates/writing_jinja_templates.rst
@@ -377,7 +377,7 @@ The extension is highly configurable:
         'css': '//cdnjs.cloudflare.com/ajax/libs/less.js/2.7.1/less.min.js',
     }
 
-- ``STATICLINK_DEBUG`` - Typically, whether to load the scripts in debug mode or not depends on the ``DEBUG`` setting. However, this option allows you to enable or disable debug mode for different script types regardless of the ``DEBUG`` setting::
+- ``STATICLINK_DEBUG`` - This option allows you to enable or disable debug mode for different script types::
 
     STATICLINK_DEBUG = {
        'css': False,

--- a/examples/simple/project/settings/base.py
+++ b/examples/simple/project/settings/base.py
@@ -153,7 +153,7 @@ STATICLINK_CLIENT_COMPILERS = {
 
 # Set debug mode for static asset compilation separately from main DEBUG setting
 # STATICLINK_DEBUG = {
-#     'css': False,
+#     'css': True,
 # }
 
 # Set path within STATICFILES_DIRS setting where static files can be located.

--- a/gn_django/template/extensions.py
+++ b/gn_django/template/extensions.py
@@ -178,15 +178,14 @@ class StaticLinkExtension(Extension):
 
     def _is_debug(self, ext):
         """
-        Check if debug mode is enabled for a file type. If it does not exist
-        in the `STATICLINK_DEBUG` setting, it will default to the `DEBUG` setting
+        Check if debug mode is enabled for a file type.
 
         Params:
             - `ext` - The file extension to check the debug mode for
         """
         if hasattr(dj_settings, 'STATICLINK_DEBUG'):
             return dj_settings.STATICLINK_DEBUG.get(ext, dj_settings.DEBUG)
-        return dj_settings.DEBUG
+        return False
 
     def _get_file_dir(self, ext):
         """


### PR DESCRIPTION
- [x] Is this Pull Request ready for review?
- [x] Do the tests pass?
- [x] Have the docs been updated?

**What does this Pull Request do?**
This PR changes the default behaviour for debug mode in the `StaticLinkExtension`. Originally, it would default to whatever the `DEBUG` setting was unless explicitly set in the `STATICLINK_DEBUG` mode. However, talking to Craig it seems like, since Gulp automatically compiles the files, he would rather not have to worry about disabling debug mode when working on it, but it would still be good to have the ability to view the uncompiled LESS files

**Any background context you want to provide?**
This came up when Craig was reviewing the DF4K integration

**What are the relevant Github Issues or Zendesk tickets?**
https://github.com/gamernetwork/df4k/pull/81

**Where can the reviewer see this in action?**
http://propjoe.th.gntech.systems:9986/static-link-extension