### PR TITLE
Add an AppsRouter for DB routing of one or more django apps

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,6 +49,7 @@ to use when building django applications and sites at Gamer Network.
    packages/app
    packages/template
    packages/test
+   packages/db
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/packages/db.rst
+++ b/docs/source/packages/db.rst
@@ -1,0 +1,31 @@
+.. _package-db:
+
+DB
+==
+
+The ``db`` package contains functionality relating to dealing with the
+django database layer.
+
+The ``gn_django.db.db_routers.AppsRouter`` class
+------------------------------------------------
+
+A router to route DB operations for one or more django apps to a particular 
+database.
+
+Subclasses of ``AppsRouter`` can specify django app labels and a database name
+to route DB operations to.
+
+Requires subclasses to specify class attributes:
+  * `APPS` - an iterable of django app labels
+  * `DB_NAME` - a string for the DB to route operations to
+
+e.g.
+
+.. code-block:: python
+
+    from gn_django.db.db_routers import AppsRouter
+
+    class AuthRouter(AppsRouter):
+        
+        APPS = ['auth', 'barristan']
+        DB_NAME = 'auth_db'

--- a/docs/source/packages/db.rst
+++ b/docs/source/packages/db.rst
@@ -10,7 +10,8 @@ The ``gn_django.db.db_routers.AppsRouter`` class
 ------------------------------------------------
 
 A router to route DB operations for one or more django apps to a particular 
-database.
+database.  This is a django DB router, for more information refer to
+`django's docs on DB routers <https://docs.djangoproject.com/en/1.11/topics/db/multi-db/#using-routers>`_.
 
 Subclasses of ``AppsRouter`` can specify django app labels and a database name
 to route DB operations to.

--- a/gn_django/db/db_routers.py
+++ b/gn_django/db/db_routers.py
@@ -1,0 +1,58 @@
+from gn_django.exceptions import ImproperlyConfigured
+
+class AppsRouter:
+    """
+    A router to route DB operations for one or more django apps to a particular 
+    database.
+
+    Requires class attributes to be specified:
+      - `APPS` - an iterable of django app labels
+      - `DB_NAME` - a string for the DB to route operations to
+    """
+    APPS = []
+    DB_NAME = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        no_apps = not self.APPS
+        no_db_specified = not self.DB_NAME
+        if no_apps or no_db_specified:
+            message = "There was no `APPS` attribute specified for the db router '%s'" % (self.__class__.__name__)
+            if no_db_specified:
+                message = "There was no `DB_NAME` attribute specified for the db router '%s'" % (self.__class__.__name__)
+            raise ImproperlyConfigured(message)
+
+
+    def db_for_read(self, model, **hints):
+        """
+        Attempts to read app models route to the named DB.
+        """
+        if model._meta.app_label in self.APPS:
+            return self.DB_NAME
+        return None
+
+    def db_for_write(self, model, **hints):
+        """
+        Attempts to write app models go to the named DB.
+        """
+        if model._meta.app_label in self.APPS:
+            return self.DB_NAME
+        return None
+
+    def allow_relation(self, obj1, obj2, **hints):
+        """
+        Allow relations if a model in any of the apps this router manages is involved.
+        """
+        if obj1._meta.app_label in self.APPS and \
+           obj2._meta.app_label in self.APPS:
+           return True
+        return None
+
+    def allow_migrate(self, db, app_label, model_name=None, **hints):
+        """
+        Make sure the apps' DB tables are only created in the named database.
+        """
+        if app_label in self.APPS:
+            return db == self.DB_NAME
+        return None
+

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = open(BASE_DIR + '/README.rst').read()
 
 setup(
     name='gn-django',
-    version='1.2.0',
+    version='1.4.0',
     url='https://github.com/gamernetwork/gn-django',
     description='Collection of tools and patterns for Gamer Network django apps/projects.',
     long_description=long_description,


### PR DESCRIPTION
- [X] Is this Pull Request ready for review?
- [X] Do the tests pass?
- [X] Have the docs been updated?

**What does this Pull Request do?**
Adds an `AppsRouter` class responsible for routing DB operations for one or more django apps to a named DB.
This is an abstract base class which should be extended with a concrete implementation.

**Any background context you want to provide?**
It was looking like code would be duplicated between edmonds and barristan for this, so it made sense to push it up in to here.