### PR TITLE
Defaulting static version to 'latest'

### DIFF
--- a/docs/source/jinja_templates/writing_jinja_templates.rst
+++ b/docs/source/jinja_templates/writing_jinja_templates.rst
@@ -391,7 +391,7 @@ The extension is highly configurable:
        'less': 'precompiled',
     }
 
-- ``STATICLINK_VERSION`` - A unique version number to append to the static file URLs for cache-busting. Defaults to current time stamp.
+- ``STATICLINK_VERSION`` - A unique version number to append to the static file URLs for cache-busting. Defaults to "latest".
 
 As example of this in action can be found in the ``simple`` example with the ``static-link-extnesion`` slug.
 

--- a/gn_django/template/extensions.py
+++ b/gn_django/template/extensions.py
@@ -148,7 +148,6 @@ class StaticLinkExtension(Extension):
         ext = 'js'
         file_dir = self._get_file_dir(ext)
         script_type = 'application/javascript'
-
         template = '<script src="{{ static("%s/%s.%s") }}?v=%s" type="%s"></script>' % (file_dir, name, ext, self._get_version(), script_type)
 
         return self.environment.from_string(template).render()
@@ -218,8 +217,8 @@ class StaticLinkExtension(Extension):
     def _get_version(self):
         """
         Get the version number to append to the static file URLs. This is defined
-        in the `STATICLINK_VERSION` setting, and defaults to the current timestamp.
+        in the `STATICLINK_VERSION` setting, and defaults to "latest".
         """
         if hasattr(dj_settings, 'STATICLINK_VERSION'):
             return dj_settings.STATICLINK_VERSION
-        return time.time()
+        return "latest"


### PR DESCRIPTION
- [X] Is this Pull Request ready for review?
- [X] Do the tests pass?
- [X] Have the docs been updated?

**What does this Pull Request do?**
Previously, the version GET param for staticlink-managed files would default to the current timestamp of 'STATICLINK_VERSION'.  Turns out this is a bit crazy because the chrome debugger treats these as distinct files - so you loose breakpoints etc on page reload.
I've changed this to just be 'latest' and done a related change to ansible-ng, to ensure we have a sensible `STATICLINK_VERSION` for all django deploys going forward: https://github.com/gamernetwork/ansible-ng/pull/16

This came over from the general pattern for less files in PHP apps.  I'm pretty confident we don't need to do this actually, django runserver should set all the correct cache busting headers.