### PR TITLE
Allow use of splinter selenium library for acceptance test case runner

### DIFF
--- a/docs/source/packages/test.rst
+++ b/docs/source/packages/test.rst
@@ -75,12 +75,6 @@ test application.  If you're running everything locally, this will just be
 ``'localhost'``.  If you're running through docker containers, it's likely to
 be the name of your django app container.
 
-``SELENIUM_PERSISTENT_BROWSERS`` - boolean - If this is set to ``True``, 
-test cases will attempt to reuse existing browser instances as much as possible,
-otherwise a browser instance will be spun up for each test case.  This can be
-handy for running test cases quickly as spinning up a new browser instance
-is time consuming.
-
 ``SELENIUM_RUN_FULL_SUITE`` - boolean - All acceptance test cases will run 
 if this is set to ``True``.  Otherwise, only chrome desktop test cases
 will be run.

--- a/docs/source/packages/test.rst
+++ b/docs/source/packages/test.rst
@@ -21,6 +21,18 @@ test case class, namely ``browser_name`` and ``resolution``.  A subclass of
 .. autoclass:: gn_django.test.acceptance.AcceptanceTestCase
    :members:
 
+.. note::
+
+    **Splinter or raw selenium**
+    
+    You should set a class attribute ``use_splinter=True`` on the ``AcceptanceTestCase``
+    subclass - this will mean that ``self.browser`` is a browser instance provided
+    by the splinter library.  http://splinter.readthedocs.io/en/latest/index.html
+    Splinter is a very helpful library which provides a lot of convenience methods
+    on top of the standard selenium API.  It's generally a much better interface
+    for quickly writing test cases.
+
+
 Actually, a set of tests are generally applicable to a multitude of
 browser/resolution combinations.  To avoid duplication of test code or heavy
 boilerplate, a helper function ``build_test_cases()`` is supplied.
@@ -38,12 +50,24 @@ The concrete classes can then be built with use of ``build_test_cases()`` -
 which combines the mixins specified for each permutation of browser/resolution
 supplied.
 
+.. note::
+
+    **Forcing splinter**
+
+    If you're using the ``build_test_cases()`` function, you can enforce the
+    use of splinter by setting a kwarg ``use_splinter=True`` when calling the
+    function.
+    
+
 Selenium
 ^^^^^^^^
 
+**Deprecated: It's strongly advised to use splinter (``use_splinter=True``) as
+opposed to using our extended functionality for raw selenium.**
+
 gn-django supplies some helper functionality for using the selenium webdriver API.
 
-Browser instances available on ``AcceptanceTestCase`` classes are instances
+By default, browser instances available on ``AcceptanceTestCase`` classes are instances
 of ``GNRemote``:
 
 .. autoclass:: gn_django.test.selenium.GNRemote

--- a/gn_django/test/acceptance.py
+++ b/gn_django/test/acceptance.py
@@ -26,6 +26,7 @@ class AcceptanceTestCase(StaticLiveServerTestCase):
     Subclasses of AcceptanceTestCase can define class attributes as follows:
      * ``browser_name`` - 'chrome' or 'firefox'
      * ``resolution`` - String of format '1920x1080'
+     * ``use_splinter`` - Boolean True or False - defaults to False
     """
 
     browser_name = 'chrome'
@@ -71,6 +72,9 @@ def build_test_cases(name_prefix, test_mixins, browsers, resolutions, module_nam
       * ``resolutions`` - iterable - Iterable of resolution labels.
       * ``module_name`` - string - Name of the module to define test case
         classes on.
+      * ``use_splinter`` - boolean - Whether to use splinter or not for browser
+        instances, defaults to False.
+        
 
     Returns:
       None.  Test cases are defined on the given python module.

--- a/gn_django/test/acceptance.py
+++ b/gn_django/test/acceptance.py
@@ -7,7 +7,7 @@ from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 from gn_django.url.utils import convert_to_camelcase
-from .selenium import GNRemote, browser_manager
+from .selenium import GNRemote, browser_manager, splinter_browser_manager
 
 RESOLUTIONS = {
     'desktop': '1920x1080',
@@ -31,6 +31,7 @@ class AcceptanceTestCase(StaticLiveServerTestCase):
     browser_name = 'chrome'
     resolution = RESOLUTIONS['desktop']
     element_scroll_behavior = 'bottom'
+    use_splinter = False
 
     @classmethod
     def setUpClass(cls):
@@ -41,23 +42,22 @@ class AcceptanceTestCase(StaticLiveServerTestCase):
             capabilities = DesiredCapabilities.FIREFOX.copy()
             capabilities['elementScrollBehavior'] = cls.element_scroll_behavior
         capabilities['screenResolution'] = cls.resolution
-        cls.browser = browser_manager.get_browser(capabilities, test_name=cls.__name__)
+        if cls.use_splinter:
+            cls.browser = splinter_browser_manager.get_browser(capabilities, test_name=cls.__name__)
+        else:
+            cls.browser = browser_manager.get_browser(capabilities, test_name=cls.__name__)
         return super().setUpClass()
 
     @classmethod
     def tearDownClass(cls):
-        if hasattr(settings, "SELENIUM_PERSISTENT_BROWSERS") and settings.SELENIUM_PERSISTENT_BROWSERS:
-            pass
-        else:
-            cls.browser.quit()
-            
+        cls.browser.quit()
             
 
 def run_full_suite():
     run_full = hasattr(settings, 'SELENIUM_RUN_FULL_SUITE') and settings.SELENIUM_RUN_FULL_SUITE
     return [run_full, "Skipping minor selenium tests"]
 
-def build_test_cases(name_prefix, test_mixins, browsers, resolutions, module_name):
+def build_test_cases(name_prefix, test_mixins, browsers, resolutions, module_name, use_splinter=False):
     """
     Builds a set of concrete AcceptanceTestCase classes, given mixin classes 
     of test methods, browser/resolutions that should be run
@@ -97,13 +97,16 @@ def build_test_cases(name_prefix, test_mixins, browsers, resolutions, module_nam
     test_cases = []
     for browser in browsers:
         for resolution in resolutions:
-            test_parents = tuple(test_mixins + [AcceptanceTestCase])
+            base_classes = [AcceptanceTestCase]
+            test_parents = tuple(test_mixins + base_classes)
             test_case_name = ' '.join([browser, resolution, 'Test Case'])
             test_case_name = name_prefix + convert_to_camelcase(test_case_name)
             class_attrs = {
                 'browser_name': browser,
                 'resolution': RESOLUTIONS[resolution],
             }
+            if use_splinter:
+                class_attrs['use_splinter'] = True
             test_case = type(test_case_name, test_parents, class_attrs)
             test_cases.append(test_case)
             # Skip non-major test cases if run_full_suite() evaluates to false

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "django-jinja==2.3.0",
     ],
     extras_require={
-        'selenium': ['selenium==3.3.1'],
+        'selenium': ['selenium==3.3.1', 'splinter==0.8.0'],
         'autocomplete': ['django-autocomplete-light==3.2.9'],
     },
     include_package_data=True,


### PR DESCRIPTION
- [X] Is this Pull Request ready for review?
- [X] Do the tests pass?
- [X] Have the docs been updated?

**What does this Pull Request do?**
- Adds the splinter library as a dependency for the `selenium` subpackage of gn-django.  Additionally works this in to the acceptance tests interface so that splinter browsers can be used if desired.  I've avoided making splinter browsers the default to prevent BC breaks for now.
- Drops the `SELENIUM_PERSISTENT_BROWSERS` setting for now because it was just a bit too complex.  See: https://gn-docs-propjoe.dev.gamer-network.net/subprojects/gn-django/packages/test.html#settings

**Any background context you want to provide?**
Splinter is used in mcclane here: https://github.com/gamernetwork/mcclane/pull/72