### PR TITLE
Rendering templates from strings

### DIFF
--- a/gn_django/template/utils.py
+++ b/gn_django/template/utils.py
@@ -31,7 +31,7 @@ def render_from_string(template_string, context):
     Return:
       The rendered template string
     """
-    path = Environment().from_string(template_string).render(context)
+    return Environment().from_string(template_string).render(context)
 
 def get_template_dir_for_app(app_name):
     """

--- a/gn_django/template/utils.py
+++ b/gn_django/template/utils.py
@@ -1,6 +1,7 @@
 import os
 
 from django.template import loader
+from jinja2.environment import Environment
 
 def render_to_string(template, context, request=None, using=None):
     """
@@ -18,6 +19,19 @@ def render_to_string(template, context, request=None, using=None):
       The rendered template string.
     """
     return loader.render_to_string(template, context=context, request=request, using=using)
+
+def render_from_string(template_string, context):
+    """
+    Shortcut for using simple strings as templates, e.g. '<p>{{ foo }}</p>'
+
+    Args:
+      * `template_string` - string - the string to use as a template
+      * `context` - mapping - the template context
+
+    Return:
+      The rendered template string
+    """
+    path = Environment().from_string(template_string).render(context)
 
 def get_template_dir_for_app(app_name):
     """

--- a/tests/gn_django_tests/test_template.py
+++ b/tests/gn_django_tests/test_template.py
@@ -500,3 +500,10 @@ class TestTemplateUtils(TestCase):
     def test_render_to_string(self):
         rendered = utils.render_to_string("site.j2", {'site': 'eurogamer', 'namespace': 'core'})
         self.assertEquals(rendered, "Site: eurogamer\nNamespace: core")
+
+    def test_render_from_string(self):
+        rendered = utils.render_from_string('<p>{{ foo }} {{ bar }}</p>', {
+            'foo': 'Dr',
+            'bar': 'Eggman'
+        })
+        self.assertEquals(rendered, '<p>Dr Eggman</p>')


### PR DESCRIPTION
- [x] Is this Pull Request ready for review?
- [x] Do the tests pass?
- [x] Have the docs been updated?

**What does this Pull Request do?**
Adds a `gn_django.utils.template.render_from_string()` method for rendering simple templates from strings as opposed to loading from a file, e.g. `<p>{{ foo }}</p>`

**Are there new tests?**
Yeah, one to test that it works
