### PR TITLE
Add a Jinja2 extension to output the raw contents of a file

### DIFF
--- a/gn_django/template/backend.py
+++ b/gn_django/template/backend.py
@@ -12,7 +12,7 @@ from django_jinja.backend import Jinja2 as DjangoJinja2
 from django_jinja import builtins as dj_jinja_builtins
 from django_jinja.contrib._humanize.templatetags._humanize import ordinal, intcomma, intword, apnumber, naturalday, naturaltime
 
-from .extensions import SpacelessExtension, IncludeWithExtension, StaticLinkExtension
+from .extensions import SpacelessExtension, IncludeWithExtension, StaticLinkExtension, IncludeRawExtension
 from .globals import randint
 
 class Environment(jinja2.Environment):
@@ -212,4 +212,5 @@ class Jinja2(DjangoJinja2):
         base_extensions.append(SpacelessExtension)
         base_extensions.append(IncludeWithExtension)
         base_extensions.append(StaticLinkExtension)
+        base_extensions.append(IncludeRawExtension)
         return base_extensions

--- a/gn_django/template/extensions.py
+++ b/gn_django/template/extensions.py
@@ -2,6 +2,7 @@ from jinja2 import nodes, exceptions, runtime, environment
 from jinja2.ext import Extension
 from django.conf import settings as dj_settings
 from django.core import exceptions
+from django.utils.safestring import mark_safe
 
 import re, time, os
 
@@ -264,4 +265,4 @@ class IncludeRawExtension(Extension):
                     f.close()
                     break
 
-        return self.environment.from_string(output).render()
+        return output

--- a/gn_django/template/extensions.py
+++ b/gn_django/template/extensions.py
@@ -3,7 +3,7 @@ from jinja2.ext import Extension
 from django.conf import settings as dj_settings
 from django.core import exceptions
 
-import re, time
+import re, time, os
 
 class SpacelessExtension(Extension):
     """
@@ -222,3 +222,46 @@ class StaticLinkExtension(Extension):
         if hasattr(dj_settings, 'STATICLINK_VERSION'):
             return dj_settings.STATICLINK_VERSION
         return "latest"
+
+class IncludeRawExtension(Extension):
+    """
+    Extension for outputting the contents of a static file without parsing it
+    (useful for CSS).
+
+    Usage:
+        ``{% include_raw 'path/to/file.css' %}``
+
+    Params:
+        - `path/to/file.css` - Relative path to the file within a directory
+           defined in the `STATICFILES_DIRS` setting.
+    """
+
+    tags = set(['include_raw'])
+
+    def parse(self, parser):
+        first = parser.parse_expression()
+        path = parser.parse_expression()
+        call = self.call_method('_get_file', [path], lineno=first.lineno)
+        return nodes.CallBlock(call, [], [], [], lineno=first.lineno)
+
+    def _get_file(self, path, caller):
+        """
+        Render link tags for stylesheets. If debug mode is enabled this will be
+        the uncompiled version of the file.
+
+        Params:
+            - `path` - The path to the file
+            - `caller` - Required by Jinja
+        """
+        output = ''
+
+        if hasattr(dj_settings, 'STATICFILES_DIRS'):
+            for static_dir in dj_settings.STATICFILES_DIRS:
+                fp = os.path.join(static_dir, path)
+                if os.path.isfile(fp):
+                    f = open(fp, 'r')
+                    output = f.read()
+                    f.close()
+                    break
+
+        return self.environment.from_string(output).render()

--- a/gn_django/template/extensions.py
+++ b/gn_django/template/extensions.py
@@ -246,8 +246,8 @@ class IncludeRawExtension(Extension):
 
     def _get_file(self, path, caller):
         """
-        Render link tags for stylesheets. If debug mode is enabled this will be
-        the uncompiled version of the file.
+        Check if a file exists an the specified path, and if so then open it and
+        render the contents.
 
         Params:
             - `path` - The path to the file

--- a/tests/gn_django_tests/test_files/include_raw_templates/include.j2
+++ b/tests/gn_django_tests/test_files/include_raw_templates/include.j2
@@ -1,0 +1,9 @@
+<h1><code>include_raw</code> test</h1>
+
+<p class="red">This text is red</p>
+
+<style>
+{% include_raw 'styles.css' %}
+</style>
+
+<div id="some-id">This text is not</div>

--- a/tests/gn_django_tests/test_files/include_raw_templates/include_expected.html
+++ b/tests/gn_django_tests/test_files/include_raw_templates/include_expected.html
@@ -1,0 +1,24 @@
+<h1><code>include_raw</code> test</h1>
+
+<p class="red">This text is red</p>
+
+<style>
+body {
+  background: papayawhip;
+}
+
+.red {
+  color: red;
+}
+
+#some-id {
+  color: green;
+}
+
+/* This is to make sure the template isn't being parsed by Jinja2 - it would
+   throw an error due to the '{#' appearing to be an unclosed comment */
+@media only screen and (max-width: 1260px) {#some-id{color: rebeccapurple;}}
+
+</style>
+
+<div id="some-id">This text is not</div>

--- a/tests/gn_django_tests/test_files/include_raw_templates/styles.css
+++ b/tests/gn_django_tests/test_files/include_raw_templates/styles.css
@@ -1,0 +1,15 @@
+body {
+  background: papayawhip;
+}
+
+.red {
+  color: red;
+}
+
+#some-id {
+  color: green;
+}
+
+/* This is to make sure the template isn't being parsed by Jinja2 - it would
+   throw an error due to the '{#' appearing to be an unclosed comment */
+@media only screen and (max-width: 1260px) {#some-id{color: rebeccapurple;}}

--- a/tests/gn_django_tests/test_template.py
+++ b/tests/gn_django_tests/test_template.py
@@ -16,6 +16,7 @@ from gn_django.template.loaders import file_system_loaders
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
+
 class TestJinja2(TestCase):
     """
     Tests for the Jinja2 class.
@@ -164,6 +165,23 @@ class TestJinja2(TestCase):
         expected = jinja.get_template('include_expected.j2').render().strip()
 
         self.assertEquals(result, expected)
+
+    def test_include_raw_extension(self):
+        template_dir = os.path.join(BASE_DIR, "test_files", "include_raw_templates")
+
+        with self.settings(STATICFILES_DIRS=[template_dir]):
+            jinja_config = self.get_jinja_config()
+            jinja_config['DIRS'].append(template_dir)
+            jinja = Jinja2(jinja_config)
+
+            result = jinja.get_template('include.j2').render().strip()
+
+            expected_path = os.path.join(template_dir, "include_expected.html")
+            f = open(expected_path, 'r')
+            expected = f.read().strip()
+            f.close()
+
+            self.assertEquals(result, expected)
 
 class TestHierarchyLoader(TestCase):
     """


### PR DESCRIPTION
Add `IncludeRawExtension`, to allow the raw contents of a file to be output to a page without being parsed as a Jinja2 template.

You pass it the file path, and it checks if the file exists in any directory listed in `STATICFILES_DIRS`. If so then it opens the file and outputs the contents.

Usage: `{% include_raw "css/base.css" %}`

You can't link to stylesheets in AMP pages, so this is a requirement for https://github.com/gamernetwork/dicebreaker/issues/90