### PR TITLE
Allow unique_object_slug() to take a model class instead of an object

### DIFF
--- a/gn_django/utils/models.py
+++ b/gn_django/utils/models.py
@@ -15,7 +15,7 @@ def unique_object_slug(obj, source, slug_field='slug', limit=10000):
     elif issubclass(obj, Model):
         model = obj
     else:
-        raise Exception('Object is not a model or model class: %s' % repr(obj))
+        raise ValueError('Object is not a model or model class: %s' % repr(obj))
 
     base_slug = slugify(source)
     current_slug = base_slug

--- a/gn_django/utils/models.py
+++ b/gn_django/utils/models.py
@@ -1,3 +1,4 @@
+from django.db.models import Model
 from django.utils.text import slugify
 
 from . import all_subclasses
@@ -9,7 +10,13 @@ def unique_object_slug(obj, source, slug_field='slug', limit=10000):
     converting an article title of 'Bloodborne 2 Announced' to 'bloodborne-2-announced'.
     If the slug is already taken it will append a numeric value, i.e. 'bloodborne-2-announced-1'
     """
-    model = obj.__class__
+    if isinstance(obj, Model):
+        model = obj.__class__
+    elif issubclass(obj, Model):
+        model = obj
+    else:
+        raise Exception('Object is not a model or model class: %s' % repr(obj))
+
     base_slug = slugify(source)
     current_slug = base_slug
     search = '%s__startswith' % slug_field


### PR DESCRIPTION
- [x] Is this Pull Request ready for review?
- [x] Do the tests pass?
- [x] Have the docs been updated?
- [x] Have any new settings been added?  Have they got comments?  Have they been added to the settings documentation page?

**What does this Pull Request do?**
This is a small change to the util function `unique_object_slug()`, allowing the `obj` argument to either be a model object (as previously), or a model class.

This makes it a bit easier to deal with creating slugs when creating objects, rather than updating existing ones.
