### PR TITLE
Add csv_download_response_dict function

### DIFF
--- a/gn_django/utils/http.py
+++ b/gn_django/utils/http.py
@@ -21,6 +21,28 @@ def csv_download_response(column_headings, data, filename, include_date=True):
           CSV writer contains the response object so any changes made to the CSV will automatically
           be added to the returned response object.
     """
+    response = _format_csv_response(filename, include_date)
+    writer = csv.writer(response)
+    writer.writerow(column_headings)
+    for row in data:
+        writer.writerow(row)
+    return (response, writer)
+
+
+def csv_download_response_dict(data, filename, include_date=True):
+    """
+    Same as `csv_download_response` but accepts a list of dicts as data. Does
+    not require column headings.
+    """
+    response = _format_csv_response(filename, include_date)
+    writer = csv.DictWriter(response, data[0].keys())
+    writer.writeheader()
+    for row in data:
+        writer.writerow(row)
+    return (response, writer)
+
+
+def _format_csv_response(filename, include_date):
     if include_date:
         filename = '%s-%s.csv' % (filename, timezone.now().strftime('%Y-%m-%d-%H-%M-%S'))
     else:
@@ -29,10 +51,4 @@ def csv_download_response(column_headings, data, filename, include_date=True):
     # Build CSV
     response = HttpResponse(content_type='text/csv')
     response['Content-Disposition'] = 'attachment; filename=%s' % filename
-    writer = csv.writer(response)
-    writer.writerow(column_headings)
-
-    for row in data:
-        writer.writerow(row)
-
-    return (response, writer)
+    return response

--- a/gn_django/utils/http.py
+++ b/gn_django/utils/http.py
@@ -33,9 +33,13 @@ def csv_download_response_dict(data, filename, include_date=True):
     """
     Same as `csv_download_response` but accepts a list of dicts as data. Does
     not require column headings.
+    Raises:
+        * `ValueError` if data is empty
     """
+    if not data:
+        raise ValueError('Data is empty')
+
     response = _format_csv_response(filename, include_date)
-    writer = csv.DictWriter(response, data[0].keys())
     writer.writeheader()
     for row in data:
         writer.writerow(row)

--- a/gn_django/utils/http.py
+++ b/gn_django/utils/http.py
@@ -33,13 +33,20 @@ def csv_download_response_dict(data, filename, include_date=True):
     """
     Same as `csv_download_response` but accepts a list of dicts as data. Does
     not require column headings.
+
+    Note, columns are ordered alphabetically.
+
     Raises:
         * `ValueError` if data is empty
     """
     if not data:
         raise ValueError('Data is empty')
 
+    # get headings
+    headings = sorted(set().union(*(d.keys() for d in data)))
+
     response = _format_csv_response(filename, include_date)
+    writer = csv.DictWriter(response, headings)
     writer.writeheader()
     for row in data:
         writer.writerow(row)

--- a/tests/gn_django_tests/test_utils_http.py
+++ b/tests/gn_django_tests/test_utils_http.py
@@ -56,3 +56,8 @@ class CSVDownloadResponseTest(TestCase):
         expected_content = b"First Name,Second Name\r\nByte,& Barq\r\nDr,Coyle\r\nHedlok,\r\nHelix,\r\n"
         self.assertEqual(response['Content-Type'], 'text/csv')
         self.assertEqual(response.content, expected_content)
+
+    def test_csv_response_dict_data_empty(self):
+        data = []
+        with self.assertRaises(ValueError):
+            response, writer = csv_download_response_dict(data, 'arms-roster')

--- a/tests/gn_django_tests/test_utils_http.py
+++ b/tests/gn_django_tests/test_utils_http.py
@@ -61,3 +61,21 @@ class CSVDownloadResponseTest(TestCase):
         data = []
         with self.assertRaises(ValueError):
             response, writer = csv_download_response_dict(data, 'arms-roster')
+
+    def test_csv_response_dict_irregular_dicts(self):
+        data = [
+            {
+                'First Name': 'Byte',
+            },
+            {
+                'Second Name': 'Coyle',
+            },
+            {
+                'First Name': 'Hedlok',
+                'Second Name': '',
+            },
+        ]
+        response, writer = csv_download_response_dict(data, 'arms-roster')
+        expected_content = b"First Name,Second Name\r\nByte,\r\n,Coyle\r\nHedlok,\r\n"
+        self.assertEqual(response['Content-Type'], 'text/csv')
+        self.assertEqual(response.content, expected_content)

--- a/tests/gn_django_tests/test_utils_http.py
+++ b/tests/gn_django_tests/test_utils_http.py
@@ -1,9 +1,10 @@
 from django.test import TestCase
 
-from gn_django.utils import csv_download_response
+from gn_django.utils import csv_download_response, csv_download_response_dict
 
 
 class CSVDownloadResponseTest(TestCase):
+
     def test_csv_response(self):
         data = (
             ('Byte', '& Barq'),
@@ -31,3 +32,27 @@ class CSVDownloadResponseTest(TestCase):
         self.assertEqual(response.content, expected_content)
         self.assertEqual(writer.__class__.__module__, '_csv')
         self.assertEqual(writer.__class__.__name__, 'writer')
+
+    def test_csv_response_dict(self):
+        data = [
+            {
+                'First Name': 'Byte',
+                'Second Name': '& Barq',
+            },
+            {
+                'First Name': 'Dr',
+                'Second Name': 'Coyle',
+            },
+            {
+                'First Name': 'Hedlok',
+                'Second Name': '',
+            },
+            {
+                'First Name': 'Helix',
+                'Second Name': '',
+            },
+        ]
+        response, writer = csv_download_response_dict(data, 'arms-roster')
+        expected_content = b"First Name,Second Name\r\nByte,& Barq\r\nDr,Coyle\r\nHedlok,\r\nHelix,\r\n"
+        self.assertEqual(response['Content-Type'], 'text/csv')
+        self.assertEqual(response.content, expected_content)


### PR DESCRIPTION
- [x] Is this Pull Request ready for review?
- [x] Do the tests pass?
- [x] Have the docs been updated?
- [x] Have any new settings been added?  Have they got comments?  Have they been added to the settings documentation page?

**What does this Pull Request do?**
Adds a new function for downloading a list of dicts as a CSV.

Behaves similarly to CSV download response but accepts a list of dicts.
Refactored response preparation step into _format_csv_response to reduce
duplication between the functions.

Adds tests coverage for new function.

**Are there new tests?**
Yes

**Any background context you want to provide?**
Part of my on-going work with CSV uploading and downloading. Passing in a list
of dicts can be easier than a list of lists depending on how your data is
structured.
