### PR TITLE
Add function to check if a view label is in registry without calling it

### DIFF
--- a/gn_django/app/view_registry.py
+++ b/gn_django/app/view_registry.py
@@ -82,3 +82,16 @@ def get(view_label):
             raise KeyError("No class based view is registered for the label '%s'.  Is the app in INSTALLED_APPS?" % view_label)
         return view(*args, **kwargs)
     return _get_view
+
+
+def view_is_in_registry(view_label):
+    """
+    Check if a view with the given label exists in the view registry.
+
+    Args:
+      * `view_label` - string - view label of format
+        `'[app_name]:[view_class_name]'`
+    """
+    initialise_view_registry()
+    app, view_name = _process_view_label(view_label)
+    return bool(_registry.get(app, {}).get(view_name))


### PR DESCRIPTION
- [x] Is this Pull Request ready for review?
- [x] Do the tests pass?
- [x] Have the docs been updated?
- [x] Have any new settings been added?  Have they got comments?  Have they been added to the settings documentation page?

**What does this Pull Request do?**
Adds a function to view registry which checks if the given view label exists in the registry without calling it. The
existing `get` method calls the view which isn't always desirable
