### PR TITLE
Add count() utility function

### DIFF
--- a/gn_django/utils/general.py
+++ b/gn_django/utils/general.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+from django.db.models import QuerySet
+
 
 def super_helper():
     return "DW all your problems are now fixed."
@@ -12,6 +14,27 @@ def all_subclasses(cls):
     """
     return set(cls.__subclasses__()).union(
         [s for c in cls.__subclasses__() for s in all_subclasses(c)])
+
+
+def count(countable):
+    """
+    Return the number of items in a QuerySet or other container.
+
+    If given a QuerySet object, this will use the count() method. Otherwise, it
+    falls back to using len().
+
+    This method offers a little convenience when duck-typing something that may
+    either be a QuerySet or a plain iterable, allowing you to pick the most
+    efficient method of counting available for the presented object.
+
+    However, note that it is NOT always more efficient to use count() over
+    len() with QuerySet objects. See the Django docs for a discussion on this:
+      https://docs.djangoproject.com/en/3.1/ref/models/querysets/#count
+    """
+    if isinstance(countable, QuerySet):
+        return countable.count()
+    else:
+        return len(countable)
 
 
 def is_sphinx_autodoc_running():

--- a/tests/gn_django_tests/test_utils_general.py
+++ b/tests/gn_django_tests/test_utils_general.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
+from django.db.models import QuerySet
 from django.test import TestCase
 
-from gn_django.utils import all_subclasses
+from gn_django.utils import all_subclasses, count
 
 
 class TestAllSubclasses(TestCase):
@@ -53,3 +56,14 @@ class TestAllSubclasses(TestCase):
 
         subclasses = list(all_subclasses(Parent))
         self.assertEqual(len(subclasses), 0)
+
+
+class TestCount(TestCase):
+    @patch('django.db.models.QuerySet.count')
+    def test_count_queryset(self, qs_count):
+        qs_count.return_value = 7
+        qs = QuerySet()
+        self.assertEqual(7, count(qs))
+
+    def test_count_iterable(self):
+        self.assertEqual(7, count([0, 1, 2, 3, 4, 5, 6]))


### PR DESCRIPTION
This adds a `count()` utility which can be used to count something that may either be a QuerySet or a plain (countable) iterable. As the docstring mentions, this is to make it a bit easier to count things when you're using duck-typing and thus don't know exactly what's being passed in, but would still like to count it efficiently if it's a large set.