### PR TITLE
Allow Selenium hub port to be configured

### DIFF
--- a/docs/source/packages/test.rst
+++ b/docs/source/packages/test.rst
@@ -94,6 +94,9 @@ to only run the other test layers.
 ``SELENIUM_HUB_HOST`` - string - The hostname for the selenium hub instance used
 to drive browsers.
 
+``SELENIUM_HUB_PORT`` - int - The port number for the selenium hub instance used
+to drive browsers.
+
 ``SELENIUM_APP_HOST`` - string - The hostname which resolves to the django 
 test application.  If you're running everything locally, this will just be 
 ``'localhost'``.  If you're running through docker containers, it's likely to

--- a/gn_django/test/selenium.py
+++ b/gn_django/test/selenium.py
@@ -137,8 +137,10 @@ class BrowserManager:
 
     def _get_instantiated_browser(self, width, height, capabilities):
         element_scroll_behavior = capabilities.get('elementScrollBehavior')
+        host = getattr(settings, 'SELENIUM_HUB_HOST', 'localhost')
+        port = getattr(settings, 'SELENIUM_HUB_PORT', 4444)
         kwargs = {
-            'command_executor': "http://%s:4444/wd/hub" % settings.SELENIUM_HUB_HOST,
+            'command_executor': "http://%s:%d/wd/hub" % (host, port),
             'desired_capabilities': capabilities,
         }
         if element_scroll_behavior:
@@ -170,8 +172,10 @@ class SplinterBrowserManager(BrowserManager):
 
     def _get_instantiated_browser(self, width, height, capabilities):
         element_scroll_behavior = capabilities.get('elementScrollBehavior')
+        host = getattr(settings, 'SELENIUM_HUB_HOST', 'localhost')
+        port = getattr(settings, 'SELENIUM_HUB_PORT', 4444)
         browser = SplinterBrowser(driver_name="remote",
-            url="http://%s:4444/wd/hub" % settings.SELENIUM_HUB_HOST,
+            url="http://%s:%d/wd/hub" % (host, port),
             browser=capabilities["browserName"],
             **capabilities)
         browser.driver.implicitly_wait(1)


### PR DESCRIPTION
This updates the Selenium test runner to allow the port number to be configured using `SELENIUM_HUB_PORT`, rather than hard-coding the default port number of 4444.

The new setting is optional, and will default back to 4444 if not specified.