### PR TITLE
Update selenium extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ setup(
         'pytz',
     ],
     extras_require={
-        'selenium': ['selenium==3.3.1', 'splinter==0.8.0'],
+        'selenium': [
+            'selenium==3.141.0',
+            'splinter==0.14.0',
+        ],
         'autocomplete': [
             'django-autocomplete-light>=3.3,<4.0.0',
             'django-select2>=7.4.2,<8.0',


### PR DESCRIPTION
This updates the gn-django[selenium] requirements from `selenium 3.3.1, splinter 0.8.0` to `selenium 3.141.0, splinter 0.14.0`.

The original combination is completely broken by the new pip resolver, as splinter 0.8 is not compatible with the older Selenium version.

This new combination works fine on Gravity, but I haven't tested it with any of our other projects. Since the original combination no longer installs at all, even if the new versions completely break our test suites it won't be a backwards step. But it may require us to do a bit of further tweaking of course.