### PR TITLE
Add Gfycat URL detection

### DIFF
--- a/gn_django/video/gfycat.py
+++ b/gn_django/video/gfycat.py
@@ -1,0 +1,17 @@
+import re
+
+
+def get_id(url):
+    """
+    Extract the Gfycat ID from a Gfycat URL.
+
+    Args:
+        * `url` - `string` - The URL to pull the ID from
+    Returns:
+        * A `string` if successful or `None` if not
+    """
+    if "gfycat" in url:
+        match = re.search(r'^https?:\/\/(?:www.)?gfycat.com\/ifr\/([A-Za-z0-9\-_]+)(?:\/)?(?:\?.*)?$', url)
+        if match:
+            return match.group(1)
+    return None

--- a/gn_django/video/youtube.py
+++ b/gn_django/video/youtube.py
@@ -1,6 +1,7 @@
 from urllib import parse
 import re
 
+
 def get_id(url):
     """
     Extract the 11 character ID from a YouTube URL. Checks that the URL
@@ -27,7 +28,8 @@ def get_id(url):
                     return match.group(0)
     return None
 
-def get_thumb(url, type = 'mqdefault'):
+
+def get_thumb(url, type='mqdefault'):
     """
     Get the YouTube thumbnail for a valid YouTube URL
     Args:


### PR DESCRIPTION
Add support for detecting Gfycat embeds from a provided URL, for example https://gfycat.com/ifr/AggressiveSilverCrayfish.