### PR TITLE
Wrap view functions in the registry

### DIFF
--- a/gn_django/app/view_registry.py
+++ b/gn_django/app/view_registry.py
@@ -1,3 +1,5 @@
+from functools import wraps
+
 from django.views.generic.base import View
 from django.apps import apps
 
@@ -31,7 +33,7 @@ def _get_views_in_module(module):
     views = [
         module_dict[c] for c in module_dict.keys() if (
             type(module_dict[c]) == type and
-            issubclass(module_dict[c], View) and 
+            issubclass(module_dict[c], View) and
             module_dict[c].__module__ == module.__name__
         )
     ]
@@ -46,10 +48,10 @@ def _process_view_label(view_label):
 
 def initialise_view_registry():
     """
-    Goes through all installed apps which use GNAppConfig and have a non-empty 
+    Goes through all installed apps which use GNAppConfig and have a non-empty
     view registry and initialises the project's view registry.
 
-    Repeated calls will return the cached registry early if the global 
+    Repeated calls will return the cached registry early if the global
     view registry is already populated.
     """
     if _registry:
@@ -67,21 +69,25 @@ def initialise_view_registry():
 
 def get(view_label):
     """
-    Retrieve the view callable for the view label of format 
+    Retrieve the view callable for the view label of format
     ``'[app_name]:[view_class_name]'``
 
     Args:
       * ``view_label`` - string - view label of format `'[app_name]:[view_class_name]'`
     """
     app, view_name = _process_view_label(view_label)
-    def _get_view(*args, **kwargs):
-        initialise_view_registry()
-        try:
-            view = _registry[app][view_name]
-        except KeyError:
-            raise KeyError("No class based view is registered for the label '%s'.  Is the app in INSTALLED_APPS?" % view_label)
+    initialise_view_registry()
+    view = _registry.get(app, {}).get(view_name)
+
+    def wrapped_view(*args, **kwargs):
+        if not view:
+            raise KeyError(
+                "No class based view is registered for the label '%s'.  Is "
+                "the app in INSTALLED_APPS?" % view_label
+            )
         return view(*args, **kwargs)
-    return _get_view
+
+    return wraps(view)(wrapped_view)
 
 
 def view_is_in_registry(view_label):

--- a/tests/gn_django_tests/test_view_registry.py
+++ b/tests/gn_django_tests/test_view_registry.py
@@ -55,6 +55,21 @@ class TestViewRegistry(TestCase):
                 called_view = view_wrapper()
                 self.assertEquals(view_func(), called_view)
 
+    def test_get_wraps(self):
+        """
+        Test that views are wrapped, i.e. properties on the original view
+        function still exist on the registry version.
+        """
+        view_func = mock.Mock()
+        setattr(view_func, 'some_arbitary_attr', 'some_value')
+        with mock.patch.dict(view_registry._registry, {
+            'main': {'TestView': view_func},
+        }):
+            view_wrapper = view_registry.get('main:TestView')
+            self.assertEqual(
+                'some_value',
+                getattr(view_wrapper, 'some_arbitary_attr'),
+            )
 
     def test_view_registry_in_project(self):
         """

--- a/tests/gn_django_tests/test_view_registry.py
+++ b/tests/gn_django_tests/test_view_registry.py
@@ -11,7 +11,7 @@ class TestViewRegistry(TestCase):
 
     def test_initialise_view_registry(self):
         """
-        Test the initialise_view_registry function successfully builds a 
+        Test the initialise_view_registry function successfully builds a
         view registry from a mocked apps config.
         """
         first_app = mock.Mock(spec=GNAppConfig)
@@ -32,7 +32,7 @@ class TestViewRegistry(TestCase):
                 'Article': second_app.views['content:Article'].as_view(),
             }
         }
-        with mock.patch.dict(view_registry._registry, {}):
+        with mock.patch.dict(view_registry._registry, {}, clear=True):
             with mock.patch("django.apps.apps.get_app_configs") as mocked_get_app_configs:
                 mocked_get_app_configs.return_value = mocked_app_config
                 view_registry.initialise_view_registry()
@@ -54,7 +54,7 @@ class TestViewRegistry(TestCase):
                 view_wrapper = view_registry.get('main:%s' % view_name)
                 called_view = view_wrapper()
                 self.assertEquals(view_func(), called_view)
-            
+
 
     def test_view_registry_in_project(self):
         """


### PR DESCRIPTION
- [x] Is this Pull Request ready for review?
- [x] Do the tests pass?
- [x] Have the docs been updated?
- [x] Have any new settings been added?  Have they got comments?  Have they been added to the settings documentation page?

**What does this Pull Request do?**
This updates the behaviour of the view registry so that it now provides wrapped view functions, instead of encasing them.

The previous behaviour meant that any special attributes set on the view (e.g. by using the `csrf_exempt` decorator) were not passed through when assigning the view to a URL. This prevents some decorators from working correctly, unless said decorators are also added to urlconf, which is not ideal.

A consequence of this is that `initialise_view_registry()` is now called immediately when setting up the URL config rather than when a view is first accessed. I do not believe this change will result in any adverse behaviour.

The existing functionality of allowing views to be overridden incrementally is unaffected by this change, and the registry is still only initialised once.

**Are there new tests?**
Yes

**What are the relevant Github Issues or Zendesk tickets?**
n/a

**How should this be tested?**
Unit tests cover the new behaviour. You can also test this change with any existing site, it shouldn't affect any existing stuff.