### PR TITLE
Raise exception if app config contains no views

### DIFF
--- a/gn_django/app/view_registry.py
+++ b/gn_django/app/view_registry.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from functools import wraps
 
 from django.views.generic.base import View
@@ -56,6 +57,7 @@ def initialise_view_registry():
     """
     if _registry:
         return
+    registry = defaultdict(dict)
     all_apps = apps.get_app_configs()
     for app in all_apps:
         if isinstance(app, GNAppConfig):
@@ -67,12 +69,9 @@ def initialise_view_registry():
                     'initialise views before all apps are ready.'
                 )
             for label, view in app.views.items():
-                app, view_name = _process_view_label(label)
-                try:
-                    _registry[app][view_name] = view.as_view()
-                except KeyError:
-                    _registry[app] = {}
-                    _registry[app][view_name] = view.as_view()
+                app_name, view_name = _process_view_label(label)
+                registry[app_name][view_name] = view.as_view()
+    _registry.update(registry)
 
 def get(view_label):
     """

--- a/gn_django/app/view_registry.py
+++ b/gn_django/app/view_registry.py
@@ -58,7 +58,14 @@ def initialise_view_registry():
         return
     all_apps = apps.get_app_configs()
     for app in all_apps:
-        if isinstance(app, GNAppConfig) and app.views:
+        if isinstance(app, GNAppConfig):
+            if not app.views:
+                raise Exception(
+                    f'No views were found in {app.__class__}. This may indicate '
+                    'that views were initialised prematurely. Check that you '
+                    'are not resolving URLs or any other actions that '
+                    'initialise views before all apps are ready.'
+                )
             for label, view in app.views.items():
                 app, view_name = _process_view_label(label)
                 try:

--- a/tests/gn_django_tests/test_view_registry.py
+++ b/tests/gn_django_tests/test_view_registry.py
@@ -38,6 +38,31 @@ class TestViewRegistry(TestCase):
                 view_registry.initialise_view_registry()
                 self.assertEquals(view_registry._registry, expected_registry)
 
+    def test_initialise_view_registry_empty_app(self):
+        """
+        Test that a registered app with no views raises an exception.
+        """
+        first_app = mock.Mock(spec=GNAppConfig)
+        first_app.name = 'core'
+        first_app.views = {'core:Home': mock.Mock(spec=View)}
+        second_app = mock.Mock(spec=GNAppConfig)
+        second_app.name = 'content'
+        second_app.views = {}
+        mocked_app_config = [first_app, second_app]
+        with mock.patch.dict(view_registry._registry, {}, clear=True):
+            with mock.patch('django.apps.apps.get_app_configs') as mocked_get_app_configs:
+                mocked_get_app_configs.return_value = mocked_app_config
+                with self.assertRaises(Exception) as ctx:
+                    view_registry.initialise_view_registry()
+        self.assertEqual(
+            'No views were found in <class \'gn_django.app.app_config.GNAppConfig\'>. '
+            'This may indicate that views were initialised prematurely. Check '
+            'that you are not resolving URLs or any other actions that '
+            'initialise views before all apps are ready.',
+            str(ctx.exception),
+        )
+
+
     def test_get(self):
         """
         Test that views can be retrieved from the registry successfully.


### PR DESCRIPTION
- [x] Is this Pull Request ready for review?
- [x] Do the tests pass?
- [x] Have the docs been updated?
- [x] Have any new settings been added?  Have they got comments?  Have they been added to the settings documentation page?

**What does this Pull Request do?**
A slight addition to the changes I made before. Because of the way the new registry setup works, it's now important that the views are initialised before any URLs are looked up. Doing this in the wrong order will cause some views not to be loaded.

In order to catch this, I've added a check into the view registry, it will now throw an exception if it encounters an app without any views. In most contexts, this is likely to indicate views were initialised prematurely.

**Are there new tests?**
Yes